### PR TITLE
🚨 Add missing GitHub Skills activity for urgent student registration

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Fridays, 3:00 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🚨 Urgent: Add Missing GitHub Skills Activity

This PR addresses the urgent issue #6 where students cannot register for the GitHub Skills activity that was announced by the principal.

### 📋 Changes Made
- ✅ Added **GitHub Skills** activity to the activities database
- ✅ Set capacity to 25 students to accommodate expected high demand  
- ✅ Scheduled for Mondays and Fridays, 3:00 PM - 4:30 PM
- ✅ Includes description mentioning GitHub Certifications for college applications
- ✅ Ready for immediate student registration

**Closes #6**